### PR TITLE
Add Phala's pink chain extension IDs

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,1 +1,162 @@
-[]
+[
+    {
+        "id": 4278190080,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190081,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190082,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190083,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190084,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190085,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190086,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190087,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190088,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190089,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190090,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190091,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190092,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190093,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190094,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190095,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190096,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190097,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190098,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190099,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190100,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190101,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190102,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190103,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190104,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190105,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190106,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190107,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190108,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190109,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190110,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    },
+    {
+        "id": 4278190111,
+        "repository:": "https://github.com/Phala-Network/phala-blockchain",
+        "typeName:": "PinkExt"
+    }
+]


### PR DESCRIPTION
They are used in Phala's fat-contract [there](https://github.com/Phala-Network/phala-blockchain/blob/2d5d6d1999086d89a0225af74221d17fa54d3975/crates/pink/pink-extension/src/chain_extension.rs#L37-L94).