### PR TITLE
Add `pallet-assets` chain extension.

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -5,7 +5,7 @@
         "typeName:": "Extension"
     },
     {
-        "id": 0x48f6,
+        "id": 18678,
         "repository:": "https://github.com/Supercolony-net/pallet-assets-chain-extension",
         "typeName:": "AssetsExtension"
     }

--- a/registry.json
+++ b/registry.json
@@ -3,5 +3,10 @@
         "id": 1,
         "repository:": "https://github.com/paritytech/pallet-contracts-xcm",
         "typeName:": "Extension"
+    },
+    {
+        "id": 0x48f6,
+        "repository:": "https://github.com/Supercolony-net/pallet-assets-chain-extension",
+        "typeName:": "AssetsExtension"
     }
 ]


### PR DESCRIPTION
The id of the chain extension is `0x48f6`. It is the first 2 bytes of the `blake2b` hash from the "pallet-assets-chain-extension@v0.1" string.
The [chain extension](https://github.com/Supercolony-net/pallet-assets-chain-extension) created with usage of the [`obce`](https://github.com/Supercolony-net/obce) crate.

The chain extension is not ready for production because it requires some additional changes on the `pallet-assets` side(some operations should be performed by the contract only if the contract is admin).
But it is a matter of time, so I think we can register it and fix it with minor patches.

Added support of the extension into [substrate-contract-node](https://github.com/paritytech/substrate-contracts-node/pull/146) and into [OpenBrush](https://github.com/Supercolony-net/openbrush-contracts/pull/168).